### PR TITLE
fix: wrong path in devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -42,7 +42,7 @@
   "forwardPorts": [8000],
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "/.devcontainer/postCreateCommand.sh",
+  "postCreateCommand": "./.devcontainer/postCreateCommand.sh",
 
   // Set minimal host requirements for the container.
   "hostRequirements": {


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
postCreateCommand script path is wrong

2024-08-29 08:03:38.472Z: /.devcontainer/postCreateCommand.sh
2024-08-29 08:03:38.880Z: /bin/sh: 1: /.devcontainer/postCreateCommand.sh: not found
2024-08-29 08:03:38.909Z: postCreateCommand failed with exit code 127. Skipping any further user-provided commands.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Create GitHub code space from this repo
* Open the creation log

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->